### PR TITLE
Include API in Articulate compose file

### DIFF
--- a/dockerfiles/docker-compose-articulateui.yml
+++ b/dockerfiles/docker-compose-articulateui.yml
@@ -7,6 +7,14 @@ services:
     networks: ['botsharp-network']
     environment:
      - API_URL
+  
+  api:
+    image: samtecspg/articulate-api:0.12.1
+    ports: ['0.0.0.0:7500:7500']
+    networks: ['botsharp-network']
+    entrypoint: ['node', 'start.js']
+    environment:
+     - SWAGGER_BASE_PATH
 
   botsharp:
     image: botsharpdocker/botsharp-rasa:latest


### PR DESCRIPTION
There was an issue opened on our repo, where a user couldn't connect to the API, but the API wasn't included in this compose. So that was the problem.